### PR TITLE
fix: raw codec is 0x55

### DIFF
--- a/src/app/[locale]/specs/blob/page.mdx
+++ b/src/app/[locale]/specs/blob/page.mdx
@@ -20,7 +20,7 @@ Currently, the only "blessed" CID type for blobs is similar to that for reposito
 
 - CIDv1
 - Multibase: binary serialization within DAG-CBOR (or `base32` for JSON mappings)
-- Multicodec: `raw` (0x00)
+- Multicodec: `raw` (0x55)
 - Multihash: `sha-256` with 256 bits (0x12)
 
 An example blob CID, in base32 string encoding: `bafkreibjfgx2gprinfvicegelk5kosd6y2frmqpqzwqkg7usac74l3t2v4`


### PR DESCRIPTION
The raw codec is 0x55 rather than 0x00 (see https://github.com/multiformats/multicodec/blob/d08f5064ce50e9e7fabc5bb9a7eeb169ccefebda/table.csv#L41).

Also see https://cid.ipfs.tech/#bafkreibjfgx2gprinfvicegelk5kosd6y2frmqpqzwqkg7usac74l3t2v4